### PR TITLE
server: differentiating between freelancer/company and user/admin

### DIFF
--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -3,6 +3,7 @@ import type { RegisterDTO } from '#shared/dto/register.dto'
 import { registerSchema } from '#shared/dto/register.dto'
 
 import type { FormSubmitEvent, RadioGroupItem, SelectMenuItem } from '@nuxt/ui'
+import { ACCOUNT_TYPE_VALUES, COUNTRY_VALUES } from '#shared/constants/enums'
 
 // Good read: https://ui.nuxt.com/docs/components/form
 
@@ -16,10 +17,20 @@ const state = reactive<Partial<RegisterDTO>>({
   country: undefined
 })
 
-const accountTypes: RadioGroupItem[] = [
-  { label: 'Freelancer', description: 'I am looking for a job opportunity.', id: 'freelancer' },
-  { label: 'Company', description: 'I am looking to hire someone.', id: 'company' }
-]
+const accountTypes: RadioGroupItem[]
+  = ACCOUNT_TYPE_VALUES.map(type => ({
+    label:
+      type === 'freelancer'
+        ? 'Freelancer'
+        : 'Company',
+
+    description:
+      type === 'freelancer'
+        ? 'I am looking for a job opportunity.'
+        : 'I am looking to hire someone.',
+
+    value: type
+  }))
 
 const countries: SelectMenuItem[] = [
   { label: 'Belgium', value: 'be' },
@@ -77,7 +88,11 @@ async function onSubmit(event: FormSubmitEvent<RegisterDTO>) {
 
       <UForm :schema="registerSchema" :state="state" class="space-y-6" @submit="onSubmit">
         <UFormField name="accountType">
-          <URadioGroup v-model="state.accountType" value-key="id" :items="accountTypes" />
+          <URadioGroup
+            v-model="state.accountType"
+            value-key="value"
+            :items="accountTypes"
+          />
         </UFormField>
 
         <div class="grid grid-cols-2 gap-4">

--- a/server/database/migrations/0000_low_violations.sql
+++ b/server/database/migrations/0000_low_violations.sql
@@ -1,11 +1,12 @@
-CREATE TYPE "public"."categoryEnum" AS ENUM('Web Development', 'Software Development', 'Network Engineering', 'Cybersecurity', 'DevOps');--> statement-breakpoint
-CREATE TYPE "public"."countryEnum" AS ENUM('Luxembourg', 'France', 'Belgium', 'Germany');--> statement-breakpoint
-CREATE TYPE "public"."languageEnum" AS ENUM('English', 'German', 'French');--> statement-breakpoint
-CREATE TYPE "public"."offerStatusEnum" AS ENUM('Active', 'Paused', 'Deleted');--> statement-breakpoint
-CREATE TYPE "public"."orderStatusEnum" AS ENUM('Pending', 'Accepted', 'Rejected', 'Completed', 'Cancelled');--> statement-breakpoint
-CREATE TYPE "public"."roleEnum" AS ENUM('Freelancer', 'Company', 'Admin');--> statement-breakpoint
-CREATE TYPE "public"."skillsEnum" AS ENUM('C', 'C#', 'C++', 'Go', 'Java', 'JavaScript', 'PHP', 'Python', 'Rust', 'TypeScript');--> statement-breakpoint
-CREATE TYPE "public"."workPlaceEnum" AS ENUM('On site', 'Remote', 'Hybrid');--> statement-breakpoint
+CREATE TYPE "public"."accountTypeEnum" AS ENUM('freelancer', 'company');--> statement-breakpoint
+CREATE TYPE "public"."categoryEnum" AS ENUM('web_development', 'software_development', 'network_engineering', 'cybersecurity', 'devops');--> statement-breakpoint
+CREATE TYPE "public"."countryEnum" AS ENUM('be', 'de', 'fr', 'lu');--> statement-breakpoint
+CREATE TYPE "public"."languageEnum" AS ENUM('en', 'de', 'fr', 'lu');--> statement-breakpoint
+CREATE TYPE "public"."offerStatusEnum" AS ENUM('active', 'paused', 'deleted');--> statement-breakpoint
+CREATE TYPE "public"."orderStatusEnum" AS ENUM('pending', 'accepted', 'rejected', 'completed', 'cancelled');--> statement-breakpoint
+CREATE TYPE "public"."roleTypeEnum" AS ENUM('user', 'admin');--> statement-breakpoint
+CREATE TYPE "public"."skillsEnum" AS ENUM('c', 'csharp', 'cpp', 'go', 'java', 'javascript', 'php', 'python', 'rust', 'typescript');--> statement-breakpoint
+CREATE TYPE "public"."workPlaceEnum" AS ENUM('on_site', 'remote', 'hybrid');--> statement-breakpoint
 CREATE TABLE "offers" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"user_id" integer NOT NULL,
@@ -17,7 +18,7 @@ CREATE TABLE "offers" (
 	"duration" integer DEFAULT 1 NOT NULL,
 	"work_place" "workPlaceEnum" NOT NULL,
 	"location" "countryEnum" NOT NULL,
-	"status" "offerStatusEnum" DEFAULT 'Active' NOT NULL,
+	"status" "offerStatusEnum" DEFAULT 'active' NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );
@@ -28,7 +29,7 @@ CREATE TABLE "orders" (
 	"buyer_id" integer NOT NULL,
 	"seller_id" integer NOT NULL,
 	"price" real NOT NULL,
-	"status" "orderStatusEnum" DEFAULT 'Pending' NOT NULL,
+	"status" "orderStatusEnum" DEFAULT 'pending' NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL
 );
@@ -52,7 +53,8 @@ CREATE TABLE "users" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"email" text NOT NULL,
 	"password" text NOT NULL,
-	"role" "roleEnum" NOT NULL,
+	"account_type" "accountTypeEnum" NOT NULL,
+	"role_type" "roleTypeEnum" NOT NULL,
 	"created_at" timestamp DEFAULT now() NOT NULL,
 	"updated_at" timestamp DEFAULT now() NOT NULL,
 	CONSTRAINT "users_email_unique" UNIQUE("email")

--- a/server/database/migrations/meta/0000_snapshot.json
+++ b/server/database/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "8d1c4cee-43be-426b-8904-5cee0028b4a1",
+  "id": "1e0631aa-d357-49b3-a82b-dca3fb214d05",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -79,7 +79,7 @@
           "typeSchema": "public",
           "primaryKey": false,
           "notNull": true,
-          "default": "'Active'"
+          "default": "'active'"
         },
         "created_at": {
           "name": "created_at",
@@ -158,7 +158,7 @@
           "typeSchema": "public",
           "primaryKey": false,
           "notNull": true,
-          "default": "'Pending'"
+          "default": "'pending'"
         },
         "created_at": {
           "name": "created_at",
@@ -350,9 +350,16 @@
           "primaryKey": false,
           "notNull": true
         },
-        "role": {
-          "name": "role",
-          "type": "roleEnum",
+        "account_type": {
+          "name": "account_type",
+          "type": "accountTypeEnum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "roleTypeEnum",
           "typeSchema": "public",
           "primaryKey": false,
           "notNull": true
@@ -390,88 +397,96 @@
     }
   },
   "enums": {
+    "public.accountTypeEnum": {
+      "name": "accountTypeEnum",
+      "schema": "public",
+      "values": [
+        "freelancer",
+        "company"
+      ]
+    },
     "public.categoryEnum": {
       "name": "categoryEnum",
       "schema": "public",
       "values": [
-        "Web Development",
-        "Software Development",
-        "Network Engineering",
-        "Cybersecurity",
-        "DevOps"
+        "web_development",
+        "software_development",
+        "network_engineering",
+        "cybersecurity",
+        "devops"
       ]
     },
     "public.countryEnum": {
       "name": "countryEnum",
       "schema": "public",
       "values": [
-        "Luxembourg",
-        "France",
-        "Belgium",
-        "Germany"
+        "be",
+        "de",
+        "fr",
+        "lu"
       ]
     },
     "public.languageEnum": {
       "name": "languageEnum",
       "schema": "public",
       "values": [
-        "English",
-        "German",
-        "French"
+        "en",
+        "de",
+        "fr",
+        "lu"
       ]
     },
     "public.offerStatusEnum": {
       "name": "offerStatusEnum",
       "schema": "public",
       "values": [
-        "Active",
-        "Paused",
-        "Deleted"
+        "active",
+        "paused",
+        "deleted"
       ]
     },
     "public.orderStatusEnum": {
       "name": "orderStatusEnum",
       "schema": "public",
       "values": [
-        "Pending",
-        "Accepted",
-        "Rejected",
-        "Completed",
-        "Cancelled"
+        "pending",
+        "accepted",
+        "rejected",
+        "completed",
+        "cancelled"
       ]
     },
-    "public.roleEnum": {
-      "name": "roleEnum",
+    "public.roleTypeEnum": {
+      "name": "roleTypeEnum",
       "schema": "public",
       "values": [
-        "Freelancer",
-        "Company",
-        "Admin"
+        "user",
+        "admin"
       ]
     },
     "public.skillsEnum": {
       "name": "skillsEnum",
       "schema": "public",
       "values": [
-        "C",
-        "C#",
-        "C++",
-        "Go",
-        "Java",
-        "JavaScript",
-        "PHP",
-        "Python",
-        "Rust",
-        "TypeScript"
+        "c",
+        "csharp",
+        "cpp",
+        "go",
+        "java",
+        "javascript",
+        "php",
+        "python",
+        "rust",
+        "typescript"
       ]
     },
     "public.workPlaceEnum": {
       "name": "workPlaceEnum",
       "schema": "public",
       "values": [
-        "On site",
-        "Remote",
-        "Hybrid"
+        "on_site",
+        "remote",
+        "hybrid"
       ]
     }
   },

--- a/server/database/migrations/meta/_journal.json
+++ b/server/database/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1776868467983,
-      "tag": "0000_huge_frank_castle",
+      "when": 1776966615164,
+      "tag": "0000_low_violations",
       "breakpoints": true
     }
   ]

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,6 +1,7 @@
 import { pgTable, serial, text, pgEnum, timestamp, integer, real } from 'drizzle-orm/pg-core'
 
 import {
+  ROLE_TYPE_VALUES,
   ACCOUNT_TYPE_VALUES,
   COUNTRY_VALUES,
   WORKPLACE_VALUES,
@@ -11,7 +12,9 @@ import {
   SKILLS_VALUES
 } from '#shared/constants/enums'
 
-export const roleEnum = pgEnum('roleEnum', ACCOUNT_TYPE_VALUES)
+export const roleTypeEnum = pgEnum('roleTypeEnum', ROLE_TYPE_VALUES)
+
+export const accountTypeEnum = pgEnum('accountTypeEnum', ACCOUNT_TYPE_VALUES)
 
 export const countryEnum = pgEnum('countryEnum', COUNTRY_VALUES)
 
@@ -31,7 +34,8 @@ export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   email: text('email').notNull().unique(),
   password: text('password').notNull(),
-  role: roleEnum('role').notNull(),
+  accountType: accountTypeEnum('account_type').notNull(),
+  roleType: roleTypeEnum('role_type').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 })
@@ -61,7 +65,7 @@ export const offers = pgTable('offers', {
   duration: integer('duration').default(1).notNull(),
   workPlace: workPlaceEnum('work_place').notNull(),
   location: countryEnum('location').notNull(),
-  status: offerStatusEnum('status').default('Active').notNull(),
+  status: offerStatusEnum('status').default('active').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 })
@@ -72,7 +76,7 @@ export const orders = pgTable('orders', {
   buyerId: integer('buyer_id').notNull().references(() => users.id),
   sellerId: integer('seller_id').notNull().references(() => users.id),
   price: real('price').notNull(),
-  status: orderStatusEnum('status').default('Pending').notNull(),
+  status: orderStatusEnum('status').default('pending').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 })

--- a/server/services/register.service.ts
+++ b/server/services/register.service.ts
@@ -20,7 +20,8 @@ export async function registerUser(db: any, tables: any, dto: RegisterDTO) {
       .values({
         email: dto.email,
         password: hashedPassword,
-        role: dto.role
+        accountType: dto.accountType,
+        roleType: 'user'
       })
       .returning()
 

--- a/shared/constants/enums.ts
+++ b/shared/constants/enums.ts
@@ -1,5 +1,7 @@
 export const ACCOUNT_TYPE_VALUES = ['freelancer', 'company'] as const
 
+export const ROLE_TYPE_VALUES = ['user', 'admin'] as const
+
 export const COUNTRY_VALUES = ['be', 'de', 'fr', 'lu'] as const
 
 export const WORKPLACE_VALUES = ['on_site', 'remote', 'hybrid'] as const

--- a/shared/dto/register.dto.ts
+++ b/shared/dto/register.dto.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { LANGUAGE_VALUES, COUNTRY_VALUES, ACCOUNT_TYPE_VALUES } from '#shared/constants/enums'
+import { LANGUAGE_VALUES, COUNTRY_VALUES, ACCOUNT_TYPE_VALUES, ROLE_TYPE_VALUES } from '#shared/constants/enums'
 
 export const registerSchema = z.object({
   accountType: z.enum(ACCOUNT_TYPE_VALUES),
@@ -13,7 +13,7 @@ export const registerSchema = z.object({
   country: z.enum(COUNTRY_VALUES, 'Please select a country'),
 
   // Unused for now
-  houseNumber: z.int().optional(),
+  houseNumber: z.coerce.number().int().optional(),
   street: z.string().trim().min(1).optional(),
   zip: z.string().trim().min(1).optional(),
   language: z.enum(LANGUAGE_VALUES).optional()


### PR DESCRIPTION
This pull request aims to introduce a distinction between :
-> freelancer vs company
-> user vs admin

The database schema and the RegisterDTO have been updated to reflect this change in the fields.

By default, users created by the register.service are created as 'user'.