### PR TITLE
docs: bruno files for manual api testing

### DIFF
--- a/testing/bruno/Transcendence-documentation.html
+++ b/testing/bruno/Transcendence-documentation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transcendence - API Documentation</title>
+    <style>
+        body { margin: 0; padding: 0; }
+        #opencollection-container { width: 100vw; height: 100vh; }
+    </style>
+    <link rel="stylesheet" href="https://cdn.opencollection.com/docs.css">
+    <script src="https://cdn.opencollection.com/docs.js"></script>
+</head>
+<body>
+    <div id="opencollection-container"></div>
+    <script>
+        const collectionData = "opencollection: 1.0.0\ninfo:\n  name: Transcendence\nconfig:\n  proxy:\n    inherit: true\n    config:\n      protocol: http\n      hostname: ''\n      port: ''\n      auth:\n        username: ''\n        password: ''\n      bypassProxy: ''\nitems:\n  - info:\n      name: docs\n      type: folder\n    items:\n      - info:\n          name: auth\n          type: folder\n        items:\n          - info:\n              name: login.post.ts\n              type: http\n              seq: 2\n            http:\n              method: POST\n              url: http://localhost:3000/api/auth/login\n              body:\n                type: json\n                data: |-\n                  {\n                    \"email\": \"42student@42luxembourg.lu\",\n                    \"password\": \"myPassword\"\n                  }\n              auth: inherit\n            settings:\n              encodeUrl: true\n              timeout: 0\n              followRedirects: true\n              maxRedirects: 5\n          - info:\n              name: register.post.ts\n              type: http\n              seq: 1\n            http:\n              method: POST\n              url: http://localhost:3000/api/auth/register\n              body:\n                type: json\n                data: |-\n                  {\n                    \"accountType\": \"freelancer\",\n                    \"firstName\": \"Max\",\n                    \"lastName\": \"Mustermann\",\n                    \"email\": \"42student@42luxembourg.lu\",\n                    \"password\": \"myPassword\",\n                    \"country\": \"lu\",\n                    \"houseNumber\": 14,\n                    \"street\": \"Porte de France\",\n                    \"zip\": \"4360\",\n                    \"language\": \"fr\"\n                  }\n              auth: inherit\n            settings:\n              encodeUrl: true\n              timeout: 0\n              followRedirects: true\n              maxRedirects: 5\n      - info:\n          name: profile\n          type: folder\n        items:\n          - info:\n              name: me.get.ts\n              type: http\n              seq: 4\n            http:\n              method: GET\n              url: http://localhost:3000/api/auth/me\n              body:\n                type: json\n                data: ''\n              auth: inherit\n            settings:\n              encodeUrl: true\n              timeout: 0\n              followRedirects: true\n              maxRedirects: 5\n          - info:\n              name: profile.get.ts\n              type: http\n              seq: 5\n            http:\n              method: GET\n              url: http://localhost:3000/api/profile/profile\n              auth: inherit\n            settings:\n              encodeUrl: true\n              timeout: 0\n              followRedirects: true\n              maxRedirects: 5\n          - info:\n              name: profile.post.ts\n              type: http\n              seq: 4\n            http:\n              method: POST\n              url: http://localhost:3000/api/profile/profile\n              body:\n                type: json\n                data: |-\n                  {\n                    \"firstName\": \"Gustave\",\n                    \"lastName\": \"Eiffel\",\n                    \"country\": \"fr\",\n                    \"houseNumber\": 15, \n                    \"street\": \"Champ de Mars\",\n                    \"zip\": \"75007\",\n                    \"language\": \"fr\"\n                  }\n              auth: inherit\n            settings:\n              encodeUrl: true\n              timeout: 0\n              followRedirects: true\n              maxRedirects: 5\n  - info:\n      name: env\n      type: folder\nbundled: true\nextensions:\n  bruno:\n    ignore:\n      - node_modules\n      - .git\n    exportedAt: '2026-04-26T19:30:56.790Z'\n    exportedUsing: Bruno/3.3.0\n";
+        new window.OpenCollection({
+            target: document.getElementById('opencollection-container'),
+            opencollection: collectionData,
+            theme: 'light',
+            gitCollectionUrl: "git@github.com:iboukhss/ft-transcendence.git"
+        });
+    </script>
+</body>
+</html>

--- a/testing/bruno/docs/auth/login.post.ts.yml
+++ b/testing/bruno/docs/auth/login.post.ts.yml
@@ -1,0 +1,22 @@
+info:
+  name: login.post.ts
+  type: http
+  seq: 2
+
+http:
+  method: POST
+  url: http://localhost:3000/api/auth/login
+  body:
+    type: json
+    data: |-
+      {
+        "email": "42student@42luxembourg.lu",
+        "password": "myPassword"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/testing/bruno/docs/auth/login.post.ts.yml
+++ b/testing/bruno/docs/auth/login.post.ts.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: POST
-  url: http://localhost:3000/api/auth/login
+  url: https://localhost:3000/api/auth/login
   body:
     type: json
     data: |-

--- a/testing/bruno/docs/auth/register.post.ts.yml
+++ b/testing/bruno/docs/auth/register.post.ts.yml
@@ -1,0 +1,30 @@
+info:
+  name: register.post.ts
+  type: http
+  seq: 1
+
+http:
+  method: POST
+  url: http://localhost:3000/api/auth/register
+  body:
+    type: json
+    data: |-
+      {
+        "accountType": "freelancer",
+        "firstName": "Max",
+        "lastName": "Mustermann",
+        "email": "42student@42luxembourg.lu",
+        "password": "myPassword",
+        "country": "lu",
+        "houseNumber": 14,
+        "street": "Porte de France",
+        "zip": "4360",
+        "language": "fr"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/testing/bruno/docs/auth/register.post.ts.yml
+++ b/testing/bruno/docs/auth/register.post.ts.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: POST
-  url: http://localhost:3000/api/auth/register
+  url: https://localhost:3000/api/auth/register
   body:
     type: json
     data: |-

--- a/testing/bruno/docs/profile/me.get.ts.yml
+++ b/testing/bruno/docs/profile/me.get.ts.yml
@@ -1,0 +1,18 @@
+info:
+  name: me.get.ts
+  type: http
+  seq: 4
+
+http:
+  method: GET
+  url: http://localhost:3000/api/auth/me
+  body:
+    type: json
+    data: ""
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/testing/bruno/docs/profile/me.get.ts.yml
+++ b/testing/bruno/docs/profile/me.get.ts.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: GET
-  url: http://localhost:3000/api/auth/me
+  url: https://localhost:3000/api/auth/me
   body:
     type: json
     data: ""

--- a/testing/bruno/docs/profile/profile.get.ts.yml
+++ b/testing/bruno/docs/profile/profile.get.ts.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: GET
-  url: http://localhost:3000/api/profile/profile
+  url: https://localhost:3000/api/profile/profile
   auth: inherit
 
 settings:

--- a/testing/bruno/docs/profile/profile.get.ts.yml
+++ b/testing/bruno/docs/profile/profile.get.ts.yml
@@ -1,0 +1,15 @@
+info:
+  name: profile.get.ts
+  type: http
+  seq: 5
+
+http:
+  method: GET
+  url: http://localhost:3000/api/profile/profile
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/testing/bruno/docs/profile/profile.post.ts.yml
+++ b/testing/bruno/docs/profile/profile.post.ts.yml
@@ -5,7 +5,7 @@ info:
 
 http:
   method: POST
-  url: http://localhost:3000/api/profile/profile
+  url: https://localhost:3000/api/profile/profile
   body:
     type: json
     data: |-
@@ -13,7 +13,7 @@ http:
         "firstName": "Gustave",
         "lastName": "Eiffel",
         "country": "fr",
-        "houseNumber": 15, 
+        "houseNumber": 15,
         "street": "Champ de Mars",
         "zip": "75007",
         "language": "fr"

--- a/testing/bruno/docs/profile/profile.post.ts.yml
+++ b/testing/bruno/docs/profile/profile.post.ts.yml
@@ -1,0 +1,27 @@
+info:
+  name: profile.post.ts
+  type: http
+  seq: 4
+
+http:
+  method: POST
+  url: http://localhost:3000/api/profile/profile
+  body:
+    type: json
+    data: |-
+      {
+        "firstName": "Gustave",
+        "lastName": "Eiffel",
+        "country": "fr",
+        "houseNumber": 15, 
+        "street": "Champ de Mars",
+        "zip": "75007",
+        "language": "fr"
+      }
+  auth: inherit
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/testing/bruno/env/local.bru
+++ b/testing/bruno/env/local.bru
@@ -1,0 +1,3 @@
+vars {
+  baseUrl: http://localhost:3000
+}

--- a/testing/bruno/opencollection.yml
+++ b/testing/bruno/opencollection.yml
@@ -1,0 +1,10 @@
+opencollection: 1.0.0
+
+info:
+  name: Transcendence
+bundled: false
+extensions:
+  bruno:
+    ignore:
+      - node_modules
+      - .git


### PR DESCRIPTION
Added the Bruno collection used for manual testing of the API routes.

Bruno also provides a useful “Create Documentation” feature that generates an HTML documentation page for all API endpoints. I have not yet fully configured the generated HTML to execute the API requests directly, but it already allows extracting the corresponding cURL commands for each route.