### PR TITLE
server: websocket for online status

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,3 +1,9 @@
+<script setup lang="ts">
+import { usePresence } from '~/composables/usePresence'
+
+usePresence()
+</script>
+
 <template>
   <UApp>
     <NuxtLayout>

--- a/app/components/LLFreelancerView.vue
+++ b/app/components/LLFreelancerView.vue
@@ -28,8 +28,7 @@ const freelancerIsConnected = computed(() => isOnline(props.profile.userId))
           :chip="{
             inset: true,
             position: 'top-left',
-            color: freelancerIsConnected ? 'success' : 'neutral',
-            size: 'md'
+            color: freelancerIsConnected ? 'success' : 'neutral'
           }"
           :alt="profile.firstName"
           size="4xl"

--- a/app/components/LLFreelancerView.vue
+++ b/app/components/LLFreelancerView.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import type { ProfileDTO } from '#shared/dto/profile.dto'
 
+import { usePresence } from '~/composables/usePresence'
 import { COUNTRY_LABELS } from '~/utils/labels'
 
-defineProps<{
+const props = defineProps<{
   profile: Extract<ProfileDTO, { type: 'freelancer' }>
   isOwnProfile?: boolean
 }>()
+
+// 1. Grab the dynamic check function from your updated usePresence composable
+const { isOnline } = usePresence()
+
+// 2. Bind it to a reactive computed property.
+// Because the underlying global Set is replaced on socket events, Vue tracks this dependencies chain perfectly!
+const freelancerIsConnected = computed(() => isOnline(props.profile.userId))
 </script>
 
 <template>
@@ -17,7 +27,9 @@ defineProps<{
           :src="profile.avatar ?? undefined"
           :chip="{
             inset: true,
-            position: 'top-left'
+            position: 'top-left',
+            color: freelancerIsConnected ? 'success' : 'neutral',
+            size: 'md'
           }"
           :alt="profile.firstName"
           size="4xl"

--- a/app/composables/useOnlineUsers.ts
+++ b/app/composables/useOnlineUsers.ts
@@ -1,0 +1,22 @@
+import { computed } from 'vue'
+
+import { usePresence } from './usePresence'
+
+export const useOnlineUsers = () => {
+  const { onlineUsersList } = usePresence()
+
+  // Check if a specific user is online
+  const has = (userId: number): boolean => {
+    return onlineUsersList.value.has(userId)
+  }
+
+  // Get all online user IDs as an array
+  const onlineArray = computed(() => {
+    return Array.from(onlineUsersList.value)
+  })
+
+  return {
+    has,
+    onlineArray
+  }
+}

--- a/app/composables/usePresence.ts
+++ b/app/composables/usePresence.ts
@@ -1,0 +1,87 @@
+// app/composables/usePresence.ts
+import { ref, watch } from 'vue'
+
+const onlineUsersList = ref<Set<number>>(new Set())
+let ws: WebSocket | null = null
+
+export const usePresence = () => {
+  // 1. Extract both the login status AND the profile user data payload from nuxt-auth-utils
+  const { loggedIn, user } = useUserSession()
+
+  const connect = async () => {
+    if (ws || !loggedIn.value || import.meta.server) return
+
+    try {
+      const data = await $fetch<{ ticket: string }>('/api/presence/auth', { method: 'POST' })
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+
+      ws = new WebSocket(`${protocol}//${window.location.host}/ws?ticket=${data.ticket}`)
+
+      // 2. ⚡ THE FINAL PIECE: Inject your own user ID into your local Set instantly.
+      // This bypasses the network echo cancellation loop and forces your own profile card green!
+      if (user.value?.id) {
+        const nextSet = new Set(onlineUsersList.value)
+        nextSet.add(Number(user.value.id))
+        onlineUsersList.value = nextSet
+      }
+
+      ws.onmessage = (event) => {
+        try {
+          if (!event.data) return
+
+          const rawPayload = typeof event.data === 'string' ? JSON.parse(event.data) : event.data
+          const innerData = rawPayload?.text || rawPayload?.message || rawPayload
+          const payload = typeof innerData === 'string' ? JSON.parse(innerData) : innerData
+
+          if (!payload || !payload.event) return
+
+          if (payload.event === 'request-status') {
+            if (ws?.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({ event: 'request-status' }))
+            }
+            return
+          }
+
+          const targetId = Number(payload.userId)
+          if (Number.isNaN(targetId)) return
+
+          const nextSet = new Set(onlineUsersList.value)
+          if (payload.event === 'online') nextSet.add(targetId)
+          if (payload.event === 'offline') nextSet.delete(targetId)
+
+          onlineUsersList.value = nextSet
+        }
+        catch (err) {
+          console.warn('Skipped non-presence message framework packet:', event.data, err)
+        }
+      }
+
+      ws.onclose = () => {
+        ws = null
+      }
+    }
+    catch (err) {
+      console.error('WebSocket connection handshake aborted:', err)
+    }
+  }
+
+  const disconnect = () => {
+    if (ws) {
+      ws.close()
+      ws = null
+    }
+    onlineUsersList.value = new Set()
+  }
+
+  if (import.meta.client) {
+    watch(loggedIn, (isLoggedIn) => {
+      if (isLoggedIn) connect()
+      else disconnect()
+    }, { immediate: true })
+  }
+
+  return {
+    onlineUsersList,
+    isOnline: (userId: number) => onlineUsersList.value.has(userId)
+  }
+}

--- a/app/pages/profiles/[id].vue
+++ b/app/pages/profiles/[id].vue
@@ -7,14 +7,16 @@ const { data: profile, error, pending } = await useFetch(`/api/profiles/${profil
 
 <template>
   <UPage v-if="profile">
-    <LLFreelancerView
-      v-if="profile.type === 'freelancer'"
-      :profile="profile"
-    />
+    <UPageBody>
+      <LLFreelancerView
+        v-if="profile.type === 'freelancer'"
+        :profile="profile"
+      />
 
-    <LLCompanyView
-      v-else
-      :profile="profile"
-    />
+      <LLCompanyView
+        v-else
+        :profile="profile"
+      />
+    </UPageBody>
   </UPage>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,7 +29,8 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-04-01',
   nitro: {
     experimental: {
-      tasks: true
+      tasks: true,
+      websocket: true
     },
     storage: {
       cache: {

--- a/server/api/presence/auth.ts
+++ b/server/api/presence/auth.ts
@@ -1,0 +1,29 @@
+// server/api/presence/auth.ts
+import { defineEventHandler, createError } from 'h3'
+import { randomUUID } from 'node:crypto'
+
+// A global in-memory map to store temporary tickets (cleans up automatically)
+// Using globalThis ensures it persists correctly during Nuxt hot-reloads in dev mode
+globalThis.wsTickets = globalThis.wsTickets || new Map<string, number>()
+
+export default defineEventHandler(async (event) => {
+  // 1. Fetch the secure session via standard HTTP cookie mechanisms
+  const session = await getUserSession(event)
+
+  if (!session?.user?.id) {
+    return throw401('User is not logged in')
+  }
+
+  // 2. Generate a random, high-entropy single-use ticket
+  const ticket = randomUUID()
+  const userId = Number(session.user.id)
+
+  // 3. Map the ticket to the userId and set a strict 10-second expiration window
+  globalThis.wsTickets.set(ticket, userId)
+  setTimeout(() => {
+    globalThis.wsTickets.delete(ticket)
+  }, 10000)
+
+  // 4. Return the ticket securely to the frontend client
+  return { ticket }
+})

--- a/server/routes/ws.ts
+++ b/server/routes/ws.ts
@@ -1,0 +1,59 @@
+// server/routes/ws.ts
+import type { Peer, Message } from 'crossws'
+
+import { defineWebSocketHandler } from 'h3'
+
+const ROOM = 'onlineUsers'
+
+export default defineWebSocketHandler({
+  async open(peer: Peer) {
+    const url = new URL(peer.request?.url || '', 'http://localhost')
+    const ticket = url.searchParams.get('ticket')
+
+    const ticketsMap = (globalThis as any).wsTickets as Map<string, number> | undefined
+    const userId = ticketsMap?.get(ticket || '')
+
+    if (!userId) {
+      peer.close(4001, 'Unauthorized Ticket')
+      return
+    }
+
+    ticketsMap?.delete(ticket!)
+    peer.context.userId = userId
+    console.log(`✅ Secure WS established for user: ${userId}`)
+
+    // 1. Subscribe to the channel
+    peer.subscribe(ROOM)
+
+    // 2. ⚡ FIX: stringify the message so CrossWS can stream it over the channel network
+    peer.publish(ROOM, JSON.stringify({ event: 'online', userId }))
+
+    // 3. ⚡ NEW: Ask all existing connected tabs in the room to broadcast their status back to this new user
+    peer.publish(ROOM, JSON.stringify({ event: 'request-status' }))
+  },
+
+  message(peer: Peer, message: Message) {
+    if (!peer.context.userId) return
+    try {
+      const data = message.json()
+
+      // 4. ⚡ FIX: When a tab hears a 'request-status' shout, it broadcasts its presence back to the room
+      if (data.event === 'request-status') {
+        peer.publish(ROOM, JSON.stringify({ event: 'online', userId: peer.context.userId }))
+      }
+    }
+    catch {
+      // Catch non-JSON traffic safely
+    }
+  },
+
+  close(peer: Peer) {
+    const userId = peer.context?.userId
+    if (userId) {
+      console.log(`❌ Closed WS: userId ${userId}`)
+      // 5. ⚡ FIX: Stringify the offline payload text string
+      peer.publish(ROOM, JSON.stringify({ event: 'offline', userId }))
+    }
+    peer.unsubscribe(ROOM)
+  }
+})


### PR DESCRIPTION
This PR updates the chip in the FreelancerView to indicate whether the user is online or offline. This features relies on a websocket.

The comments and console.log in this PR can be removed later.

The following files have been modified :

# app/app.vue 
Invoking usePresence(), this automatically activates the background authentication watcher for the entire app session.

# app/composables/usePresence.ts
This function reactively watches the client's login status. When a user logs in, it orchestrates the entire handshake.
It first triggers a standard HTTP request to the /server/api/presence/auth.ts endpoint to get a single-use ticket.
It then immediately instantiates a new WebSocket() pointing to the WebSocket Router, appending that ticket as a query parameter. It handles deep JSON framing normalization and peer synchronization requests.

# server/api/presence/auth.ts
Triggered via a standard HTTP POST $fetch from the usePresence.ts immediately upon login detection.
It reads the session cookie, generates a high-entropy, single-use connection ticket, maps it to the user's ID in global memory, and expires it after 10 seconds to prevent replay attacks.

# server/routes/ws.ts
Triggered via an HTTP Upgrade Request instantly after the client receives the auth ticket and opens the browser's native WebSocket pipeline. Nitro maps the /ws URL route directly to this file.
Handles the raw TCP socket lifecycle (open, message, close). It validates and immediately burns the ticket, assigns the verified plain numeric ID to peer.context.userId and handles room broadcasting.

# app/components/LLFreelancerView.vue (UI Layer)
Binds the profile card avatar's status chip directly to the composable's isOnline() check using a reactive Vue computed property.