### PR TITLE
docs/public-api-docs

### DIFF
--- a/_openapi.json
+++ b/_openapi.json
@@ -1,0 +1,408 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "LuxLink Public API Docs",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://localhost:3000",
+      "description": "Local Development Server",
+      "variables": {}
+    }
+  ],
+  "paths": {
+    "/api/v1/jobs/company/{id}": {
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "description": "API route used to delete a job by passing the respective job id as parameter",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      },
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "description": "API route used to retrieve a job by passing the respective job id as parameter",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "v1"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Job successfully created and registered into database.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "example": 142
+                    },
+                    "title": {
+                      "type": "string",
+                      "example": "Senior Fullstack Developer"
+                    },
+                    "description": {
+                      "type": "string",
+                      "example": "We are looking for a skilled developer..."
+                    },
+                    "category": {
+                      "type": "string",
+                      "example": "Development"
+                    },
+                    "skills": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "Vue",
+                        "TypeScript"
+                      ]
+                    },
+                    "hourlyRate": {
+                      "type": "number",
+                      "example": 65.5
+                    },
+                    "duration": {
+                      "type": "integer",
+                      "example": 6
+                    },
+                    "workplace": {
+                      "type": "string",
+                      "example": "remote"
+                    },
+                    "location": {
+                      "type": "string",
+                      "example": "LU"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "active"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2026-06-14T09:00:00Z"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2026-06-14T09:15:30Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "API route used to update a job by passing the respective job id as parameter",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title",
+                  "description",
+                  "category",
+                  "skills",
+                  "hourlyRate",
+                  "duration",
+                  "workplace",
+                  "location",
+                  "status"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "example": "Senior Fullstack Developer"
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 30,
+                    "example": "We are looking for a skilled developer with 5+ years of experience in Nuxt, Nitro, and modern web application development structures."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Must match valid JOB_CATEGORY_KEYS array string matching backend validation rules."
+                  },
+                  "skills": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "Vue",
+                      "TypeScript",
+                      "Node"
+                    ]
+                  },
+                  "hourlyRate": {
+                    "type": "number",
+                    "minimum": 0.01,
+                    "example": 65.5
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 12,
+                    "example": 6,
+                    "description": "Mission duration specified in months."
+                  },
+                  "workplace": {
+                    "type": "string",
+                    "description": "Must match valid WORKPLACE_KEYS (e.g., remote, hybrid, onsite)."
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "Must match valid COUNTRY_KEYS structure mapping rules."
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "Must match valid JOB_STATUS_KEYS array string matching validation logic."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/jobs/company": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "description": "API route used to get all posted jobs",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Job successfully created and registered into database.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "example": 142
+                    },
+                    "title": {
+                      "type": "string",
+                      "example": "Senior Fullstack Developer"
+                    },
+                    "description": {
+                      "type": "string",
+                      "example": "We are looking for a skilled developer..."
+                    },
+                    "category": {
+                      "type": "string",
+                      "example": "Development"
+                    },
+                    "skills": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "example": [
+                        "Vue",
+                        "TypeScript"
+                      ]
+                    },
+                    "hourlyRate": {
+                      "type": "number",
+                      "example": 65.5
+                    },
+                    "duration": {
+                      "type": "integer",
+                      "example": 6
+                    },
+                    "workplace": {
+                      "type": "string",
+                      "example": "remote"
+                    },
+                    "location": {
+                      "type": "string",
+                      "example": "LU"
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "active"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2026-06-14T09:00:00Z"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "example": "2026-06-14T09:15:30Z"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "API route used to post a new job",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title",
+                  "description",
+                  "category",
+                  "skills",
+                  "hourlyRate",
+                  "duration",
+                  "workplace",
+                  "location",
+                  "status"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "example": "Senior Fullstack Developer"
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 30,
+                    "example": "We are looking for a skilled developer with 5+ years of experience in Nuxt, Nitro, and modern web application development structures."
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Must match valid JOB_CATEGORY_KEYS array string matching backend validation rules."
+                  },
+                  "skills": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": [
+                      "Vue",
+                      "TypeScript",
+                      "Node"
+                    ]
+                  },
+                  "hourlyRate": {
+                    "type": "number",
+                    "minimum": 0.01,
+                    "example": 65.5
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 12,
+                    "example": 6,
+                    "description": "Mission duration specified in months."
+                  },
+                  "workplace": {
+                    "type": "string",
+                    "description": "Must match valid WORKPLACE_KEYS (e.g., remote, hybrid, onsite)."
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "Must match valid COUNTRY_KEYS structure mapping rules."
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "Must match valid JOB_STATUS_KEYS array string matching validation logic."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,7 +30,22 @@ export default defineNuxtConfig({
   nitro: {
     experimental: {
       tasks: true,
-      websocket: true
+      websocket: true,
+      openAPI: true
+    },
+    openAPI: {
+      production: 'runtime',
+      route: '/api/_openapi.json',
+      ui: {
+        scalar: {
+          route: '/api/docs',
+          theme: 'nuxt'
+        }
+      },
+      meta: {
+        title: 'LuxLink Public API Docs',
+        version: '1.0.0'
+      }
     },
     storage: {
       cache: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,6 +45,16 @@ export default defineNuxtConfig({
       meta: {
         title: 'LuxLink Public API Docs',
         version: '1.0.0'
+      },
+      components: {
+        securitySchemes: {
+          ApiKeyAuth: {
+            type: 'apiKey',
+            in: 'header',
+            name: 'x-api-key',
+            description: 'Enter your public LuxLink API key to authenticate requests.'
+          }
+        }
       }
     },
     storage: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,7 +34,7 @@ export default defineNuxtConfig({
       openAPI: true
     },
     openAPI: {
-      production: 'runtime',
+      production: false,
       route: '/api/_openapi.json',
       ui: {
         scalar: {

--- a/server/api/v1/jobs/company/[id].delete.ts
+++ b/server/api/v1/jobs/company/[id].delete.ts
@@ -14,3 +14,11 @@ export default defineEventHandler(async (event) => {
 
   return deletedJob
 })
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['v1'],
+    description: 'API route used to delete a job by passing the respective job id as parameter',
+    security: [{ ApiKeyAuth: [] }]
+  }
+})

--- a/server/api/v1/jobs/company/[id].get.ts
+++ b/server/api/v1/jobs/company/[id].get.ts
@@ -14,3 +14,11 @@ export default defineEventHandler(async (event) => {
 
   return job
 })
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['v1'],
+    description: 'API route used to retrieve a job by passing the respective job id as parameter',
+    security: [{ ApiKeyAuth: [] }]
+  }
+})

--- a/server/api/v1/jobs/company/[id].patch.ts
+++ b/server/api/v1/jobs/company/[id].patch.ts
@@ -22,3 +22,107 @@ export default defineEventHandler(async (event) => {
 
   return updatedJob
 })
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['v1'],
+    description: 'API route used to update a job by passing the respective job id as parameter',
+    security: [{ ApiKeyAuth: [] }],
+    // 1. WHAT THE USER MUST SEND (createJobSchema)
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: [
+              'title',
+              'description',
+              'category',
+              'skills',
+              'hourlyRate',
+              'duration',
+              'workplace',
+              'location',
+              'status'
+            ],
+            properties: {
+              title: {
+                type: 'string',
+                minLength: 1,
+                example: 'Senior Fullstack Developer'
+              },
+              description: {
+                type: 'string',
+                minLength: 30,
+                example: 'We are looking for a skilled developer with 5+ years of experience in Nuxt, Nitro, and modern web application development structures.'
+              },
+              category: {
+                type: 'string',
+                description: 'Must match valid JOB_CATEGORY_KEYS array string matching backend validation rules.'
+              },
+              skills: {
+                type: 'array',
+                minItems: 1,
+                items: { type: 'string' },
+                example: ['Vue', 'TypeScript', 'Node']
+              },
+              hourlyRate: {
+                type: 'number',
+                minimum: 0.01,
+                example: 65.50
+              },
+              duration: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 12,
+                example: 6,
+                description: 'Mission duration specified in months.'
+              },
+              workplace: {
+                type: 'string',
+                description: 'Must match valid WORKPLACE_KEYS (e.g., remote, hybrid, onsite).'
+              },
+              location: {
+                type: 'string',
+                description: 'Must match valid COUNTRY_KEYS structure mapping rules.'
+              },
+              status: {
+                type: 'string',
+                description: 'Must match valid JOB_STATUS_KEYS array string matching validation logic.'
+              }
+            }
+          } as any
+        }
+      }
+    },
+
+    // 2. WHAT THE SERVER RETURNS ON SUCCESS (jobSchema)
+    responses: {
+      201: {
+        description: 'Job successfully created and registered into database.',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer', example: 142 },
+                title: { type: 'string', example: 'Senior Fullstack Developer' },
+                description: { type: 'string', example: 'We are looking for a skilled developer...' },
+                category: { type: 'string', example: 'Development' },
+                skills: { type: 'array', items: { type: 'string' }, example: ['Vue', 'TypeScript'] },
+                hourlyRate: { type: 'number', example: 65.50 },
+                duration: { type: 'integer', example: 6 },
+                workplace: { type: 'string', example: 'remote' },
+                location: { type: 'string', example: 'LU' },
+                status: { type: 'string', example: 'active' },
+                createdAt: { type: 'string', format: 'date-time', example: '2026-06-14T09:00:00Z' },
+                updatedAt: { type: 'string', format: 'date-time', example: '2026-06-14T09:15:30Z' }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+})

--- a/server/api/v1/jobs/company/index.get.ts
+++ b/server/api/v1/jobs/company/index.get.ts
@@ -8,3 +8,11 @@ export default defineEventHandler(async (event) => {
 
   return jobs
 })
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['v1'],
+    description: 'API route used to get all posted jobs',
+    security: [{ ApiKeyAuth: [] }]
+  }
+})

--- a/server/api/v1/jobs/company/index.post.ts
+++ b/server/api/v1/jobs/company/index.post.ts
@@ -16,3 +16,108 @@ export default defineEventHandler(async (event) => {
 
   return job
 })
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['v1'],
+    description: 'API route used to post a new job',
+    security: [{ ApiKeyAuth: [] }],
+
+    // 1. WHAT THE USER MUST SEND (createJobSchema)
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: [
+              'title',
+              'description',
+              'category',
+              'skills',
+              'hourlyRate',
+              'duration',
+              'workplace',
+              'location',
+              'status'
+            ],
+            properties: {
+              title: {
+                type: 'string',
+                minLength: 1,
+                example: 'Senior Fullstack Developer'
+              },
+              description: {
+                type: 'string',
+                minLength: 30,
+                example: 'We are looking for a skilled developer with 5+ years of experience in Nuxt, Nitro, and modern web application development structures.'
+              },
+              category: {
+                type: 'string',
+                description: 'Must match valid JOB_CATEGORY_KEYS array string matching backend validation rules.'
+              },
+              skills: {
+                type: 'array',
+                minItems: 1,
+                items: { type: 'string' },
+                example: ['Vue', 'TypeScript', 'Node']
+              },
+              hourlyRate: {
+                type: 'number',
+                minimum: 0.01,
+                example: 65.50
+              },
+              duration: {
+                type: 'integer',
+                minimum: 1,
+                maximum: 12,
+                example: 6,
+                description: 'Mission duration specified in months.'
+              },
+              workplace: {
+                type: 'string',
+                description: 'Must match valid WORKPLACE_KEYS (e.g., remote, hybrid, onsite).'
+              },
+              location: {
+                type: 'string',
+                description: 'Must match valid COUNTRY_KEYS structure mapping rules.'
+              },
+              status: {
+                type: 'string',
+                description: 'Must match valid JOB_STATUS_KEYS array string matching validation logic.'
+              }
+            }
+          } as any
+        }
+      }
+    },
+
+    // 2. WHAT THE SERVER RETURNS ON SUCCESS (jobSchema)
+    responses: {
+      201: {
+        description: 'Job successfully created and registered into database.',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer', example: 142 },
+                title: { type: 'string', example: 'Senior Fullstack Developer' },
+                description: { type: 'string', example: 'We are looking for a skilled developer...' },
+                category: { type: 'string', example: 'Development' },
+                skills: { type: 'array', items: { type: 'string' }, example: ['Vue', 'TypeScript'] },
+                hourlyRate: { type: 'number', example: 65.50 },
+                duration: { type: 'integer', example: 6 },
+                workplace: { type: 'string', example: 'remote' },
+                location: { type: 'string', example: 'LU' },
+                status: { type: 'string', example: 'active' },
+                createdAt: { type: 'string', format: 'date-time', example: '2026-06-14T09:00:00Z' },
+                updatedAt: { type: 'string', format: 'date-time', example: '2026-06-14T09:15:30Z' }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+})


### PR DESCRIPTION
This PR adds documentation for the internal and public API under the following links : 

https://localhost:3000/api/docs
https://localhost:3000/api/_openapi.json

Only the public API routes /v1 have been documented in addition to the bare minimum.
By default, documentation is not generated in production.

This PR needs to be finalized to ensure that in production only the API v1 documentation is available.

