### PR TITLE
Fixes console errors when downloading GDPR data

### DIFF
--- a/app/pages/settings/data-request.vue
+++ b/app/pages/settings/data-request.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const toast = useToast()
+const { user } = useUserSession()
 const isExporting = ref(false)
 
 const contactState = reactive({
@@ -20,15 +21,20 @@ async function onExportData() {
   isExporting.value = true
 
   try {
+    // Common to both account types
     const [account, profile, bookings] = await Promise.allSettled([
       $fetch('/api/account'),
       $fetch('/api/profile'),
       $fetch('/api/bookings')
     ])
 
-    const [offers, jobs] = await Promise.allSettled([
-      $fetch('/api/offers/freelancer'),
-      $fetch('/api/jobs/company')
+    // Account-type-specific data
+    const isFreelancer = user.value?.accountType === 'freelancer'
+
+    const [offers, jobs, contracts] = await Promise.allSettled([
+      isFreelancer ? $fetch('/api/offers') : Promise.resolve(null),
+      isFreelancer ? Promise.resolve(null) : $fetch('/api/jobs', { query: { userId: user.value?.id } }),
+      isFreelancer ? $fetch('/api/profiles/freelancer-contracts') : Promise.resolve(null)
     ])
 
     const exportData: Record<string, any> = {
@@ -37,10 +43,11 @@ async function onExportData() {
       profile: profile.status === 'fulfilled' ? profile.value : null,
       bookings: bookings.status === 'fulfilled' ? bookings.value : null,
       offers: offers.status === 'fulfilled' ? offers.value : null,
-      jobs: jobs.status === 'fulfilled' ? jobs.value : null
+      jobs: jobs.status === 'fulfilled' ? jobs.value : null,
+      contracts: contracts.status === 'fulfilled' ? contracts.value : null
     }
 
-    // Remove null entries (endpoints that returned 403 for wrong account type)
+    // Remove null entries (not applicable to this account type, or fetch skipped)
     Object.keys(exportData).forEach((k) => {
       if (exportData[k] === null) delete exportData[k]
     })
@@ -109,6 +116,7 @@ function onContactSubmit() {
         />
       </template>
     </UCard>
+
     <UCard
       title="Exercise your rights"
       description="Submit a request to our team regarding your personal data. We will respond within 30 days as required by GDPR."

--- a/server/services/bookings/get-bookings-user.service.ts
+++ b/server/services/bookings/get-bookings-user.service.ts
@@ -1,0 +1,28 @@
+import { eq } from 'drizzle-orm'
+
+import type { DB, Tables } from '#server/utils/db.js'
+
+import { throw403 } from '#imports'
+import { toBookingsResponseDTO } from '#server/dto/bookings.dto.js'
+
+export async function getBookingsUser(db: DB, tables: Tables, userId: number, accountType: string) {
+  let filter: any = undefined
+
+  if (accountType === 'freelancer') {
+    filter = eq(tables.bookings.sellerId, userId)
+  }
+  else if (accountType === 'company') {
+    filter = eq(tables.bookings.buyerId, userId)
+  }
+  else if (accountType !== 'admin') {
+    throw403('Invalid account type')
+  }
+
+  const bookings = await db
+    .select()
+    .from(tables.bookings)
+    .where(filter)
+
+  // An empty array is a valid result (e.g. user has no bookings yet) — not an error.
+  return toBookingsResponseDTO(bookings)
+}

--- a/server/services/bookings/get-bookings-user.service.ts
+++ b/server/services/bookings/get-bookings-user.service.ts
@@ -15,8 +15,9 @@ export async function getBookingsUser(db: DB, tables: Tables, userId: number, ac
     filter = eq(tables.bookings.buyerId, userId)
   }
   else if (accountType !== 'admin') {
-    throw403('Invalid account type')
+    return throw403('Invalid account type')
   }
+  console.log(filter)
 
   const bookings = await db
     .select()


### PR DESCRIPTION
When downloading GDPR data there were errors on the console ([EVAL] requirement) due to old routes still in the code:
GET /api/jobs/company
GET /api/offers/freelancer

Also removed the code below from get-bookings-user.service.ts as no bookings is a valid result/input and should not result in error 500.

if (bookings.length === 0) {
  throw500('Bookings could not be retrieved')
}